### PR TITLE
updates README and info.yml to align tag to latest commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UW Drupal theme (formerly, UW Boundless Barrio theme)
 
-![UW Drupal theme version 0.0.5](https://img.shields.io/static/v1?label=version&message=v0.0.4&color=green)
+![UW Drupal theme version 0.0.5](https://img.shields.io/static/v1?label=version&message=v0.0.5&color=green)
 
 This is a port of the (new) [UW WordPress Theme](https://github.com/uweb/uw_wp_theme) which utilizes Bootstrap 4 built by the UMAC web team.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # UW Drupal theme (formerly, UW Boundless Barrio theme)
 
-![UW Drupal theme version 0.0.4](https://img.shields.io/static/v1?label=version&message=v0.0.4&color=green)
+![UW Drupal theme version 0.0.5](https://img.shields.io/static/v1?label=version&message=v0.0.4&color=green)
 
 This is a port of the (new) [UW WordPress Theme](https://github.com/uweb/uw_wp_theme) which utilizes Bootstrap 4 built by the UMAC web team.
 

--- a/uw_drupal_theme.info.yml
+++ b/uw_drupal_theme.info.yml
@@ -1,7 +1,7 @@
 name: "UW Drupal Theme"
 type: theme
 description: 'A Bootstrap based theme. Sub-theme of <a href="https://www.drupal.org/project/bootstrap_barrio">Bootstrap Barrio</a>. Leverages CSS, JS and HTML markup from the <a href="https://github.com/uweb/uw_wp_theme">UW WordPress theme</a> (uw_wp_theme) by the UW Marketing & Communications Web Team.'
-version: 0.0.4
+version: 0.0.5
 core: 8.x
 core_version_requirement: ^8 || ^9 || ^10
 base theme: bootstrap_barrio


### PR DESCRIPTION
Added this hotfix to align README and info.yml with a version number so we can tag the latest commit on main. This is in preparation for a version 1.0.0 release so we have a tagged revert point.